### PR TITLE
events: add ICS download fallback + bilingual clarifications for MeshUps

### DIFF
--- a/site/_layouts/event.html
+++ b/site/_layouts/event.html
@@ -83,4 +83,10 @@ END:VCALENDAR
   {{ content }}
 </div>
 
-<p><a class="button" href="{{ events_feed_webcal }}">Subscribe to all events</a></p>
+<p>
+  <a class="button" href="{{ events_feed_webcal }}">Subscribe to all events (webcal)</a>
+  <a class="button" href="{{ events_feed_url }}">Download calendar (ICS)</a>
+  <br>
+  <small>If the webcal link doesn't open in your calendar (e.g. Outlook), use "Download calendar (ICS)" and open the file in your calendar app.</small>
+  <small lang="nb">Hvis webcal-lenken ikke åpner i kalenderen din (for eksempel Outlook), bruk «Last ned kalender (ICS)» og åpne filen i kalenderappen din.</small>
+</p>

--- a/site/events/index.html
+++ b/site/events/index.html
@@ -13,6 +13,10 @@ if (window.location.hash === '#partner-events') {
 {% assign events_feed_webcal = events_feed_url | replace_first: 'https://', 'webcal://' | replace_first: 'http://', 'webcal://' %}
 <p>
   <a class="button" href="{{ events_feed_webcal }}">Subscribe to all MishMash events (webcal)</a>
+  <a class="button" href="{{ events_feed_url }}">Download calendar (ICS)</a>
+  <br>
+  <small>If the webcal link doesn't open in your calendar (e.g. Outlook), use "Download calendar (ICS)" and open the file in your calendar app.</small>
+  <small lang="nb">Hvis webcal-lenken ikke åpner i kalenderen din (for eksempel Outlook), bruk «Last ned kalender (ICS)» og åpne filen i kalenderappen din.</small>
 </p>
 {% assign all_events = site.events | where_exp: "item", "item.draft != true" %}
 {% assign future_events = all_events | where_exp: "item", "item.date >= site.time" | sort: 'date' %}
@@ -104,4 +108,8 @@ if (window.location.hash === '#partner-events') {
 
 <p>
   <a class="button" href="{{ events_feed_webcal }}">Subscribe to all MishMash events (webcal)</a>
+  <a class="button" href="{{ events_feed_url }}">Download calendar (ICS)</a>
+  <br>
+  <small>If the webcal link doesn't open in your calendar (e.g. Outlook), use "Download calendar (ICS)" and open the file in your calendar app.</small>
+  <small lang="nb">Hvis webcal-lenken ikke åpner i kalenderen din (for eksempel Outlook), bruk «Last ned kalender (ICS)» og åpne filen i kalenderappen din.</small>
 </p>

--- a/site/faq/index.md
+++ b/site/faq/index.md
@@ -146,6 +146,10 @@ MeshUps are short, weekly online events designed for sharing ongoing work and id
 
 MeshUps provide a lightweight format for connecting across disciplines and institutions. Upcoming and past MeshUps are listed on the [events page](/events/).
 
+To receive meeting links and reminders, subscribe to the MeshUps announcement list or add MeshUps to your calendar from the events page. Use the "Subscribe (webcal)" link to add the calendar directly, or use "Download calendar (ICS)" if your mail client (for example Outlook) does not open webcal links.
+
+For Norwegian: For å motta møte-lenker og påminnelser, abonner på MeshUps' annonse-liste eller legg MeshUps til i kalenderen fra arrangementsiden. Bruk «Subscribe (webcal)» for å legge kalenderen direkte til, eller bruk «Download calendar (ICS)» hvis e-postprogrammet ditt (for eksempel Outlook) ikke åpner webcal-lenker.
+
 </details>
 
 <details class="faq-item" id="are-events-open-to-the-public" markdown="1">


### PR DESCRIPTION
Adds ICS download fallback and bilingual clarifications for MeshUps subscription. Includes suggested WP6 wording: English and Norwegian.